### PR TITLE
Correct initial wsa:// example

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ There is no `com.android.vpndialogs` in WSA. However, it's possible to manually 
 appops set [package name] ACTIVATE_VPN allow
 ```
 
-#### Launching Android Apps with URL scheme
+#### Launching Android Apps with URI scheme
 Microsoft provides a custom URI scheme for WSA, making it easier to launch apps:
 ```shell
 wsa://[App Package Name]

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ appops set [package name] ACTIVATE_VPN allow
 #### Launching Android Apps with URL scheme
 Microsoft provides a custom URI scheme for WSA, making it easier to launch apps:
 ```shell
-wsl://[App Package Name]
+wsa://[App Package Name]
 ```
 For example, to launch Apple Music in WSA, use:
 ```shell


### PR DESCRIPTION
Previously said `wsl://`