### PR TITLE
Fix Broken Edit Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Contributing
 
-Thanks for your interest in contributing! Doing so is simple. Just [edit this page](/edit/master/README.md) and submit a pull request (PR) with your changes.
+Thanks for your interest in contributing! Doing so is simple. Just [edit this page](../../edit/master/README.md) and submit a pull request (PR) with your changes.
 Someone will review it and merge it in as soon as possible.
 
 When editing the Markdown, please keep these rules in mind:


### PR DESCRIPTION

Thanks for the nice summary, but I just found that the "edit this page" link does not bring me to the right place:


### Problem

> When the link starts with a `/`, it is relative to the root of the repository BUT with suffix `/blob/master/` appended automatically.

Hence, the current one is now interpreted as `github.com/[user]/wsa-app-compatibility/blob/master/edit/master/README.md`, which ends up with "err 404 page not found".


### Workaround

The two `../` introduced in the PR will remove `/blob/master/` so the link can work correctly. (it's a common trick to reference wiki pages from markdown)
