### PR TITLE
Add cronometer and ourgroceries

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ wsa://com.android.settings
 | 酷安 (CoolApk) | 11.4.3 | ⚠️ | Unable to sign in using third party apps ||
 | 创建快捷方式 (Create Shortcut) | 1.17 | ✅ | | Can be used to access any app |
 | Comixology | 3.10.18.310421 | ✅ | | |
+| Cronometer | 3.13.1 | ✅ | | |
 | CPU-Z | 1.41 | ✅ |||
 | Dcoder | 4.0.76 | ✅ | | |
 | Delivery Club | 4.64.0 | ❌ | App crashes after selecting a shipping address |||
@@ -224,6 +225,7 @@ wsa://com.android.settings
 | Oreo: Twist, Lick, Dunk | 1.5.6 | ✅ | Minor graphical glitches ||
 | OsmAnd~ | 3.9.10 | ✅ |||
 | Oto Music | 3.0.2 | ✅ || Requires app restart to refresh list |
+| OurGroceries | 4.0.10 |✅ | Premium keys require Google Play Store||
 | Outlook | 4.2138.0 | ⚠️ | Cannot activate device administrator with Outlook, which prevents activation. ||
 | One Store | 7.6.0 | ✅ |||
 | Phigros |  | ✅ |||


### PR DESCRIPTION
My limited testing shows both cronometer and ourgroceries work.

Cronometer testing is limited as I can't test if integrations into other apps works, but the basic app seems to work, in portrait and landscape, with sync

OurGroceries seems to work, in portrait and landscape, syncing across accounts. It shows ads though as recognition of a past premium purchase seems to require Google Play Store (see https://www.ourgroceries.com/faq#:~:text=paid%20for%20again.-,How%20do%20I%20transfer%20the%20upgrade%20to%20my%20new%20phone,done%20with%20a%20different%20Google%20account%20on%20the%20Play%20Store.,-Again%2C%20these%20upgrades)