### PR TITLE
Update Firefox to 102.1.1 (2015887775)

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ wsa://com.android.settings
 | Fate/Grand Order (US) FGO | 2.22.1 (135) | 11 | ✅ || A little unstable, but playable
 | Files by Google | Unknown | Android 11 | ✅ || Works fine
 | Fire Emblem Heroes | 6.0.0 | 11 | 🆖 | Requires GMS. If GMS is installed, it cannot be played due to SafetyNet error.
-| Firefox | 101.2.0 (2015885319) | 12 & 11 | ⚠️ | On Android 11, it works albeit with improperly rendered webpages. On Android 12, webpages doesn't render anymore causing to consume more resources | Tested only on Intel HD integrated graphics.
+| Firefox | 102.1.1 (2015887775) | 12 & 11 | ⚠️ | On Android 11, it works albeit with broken rendered webpages. On Android 12, webpages now renders but there's a white box, a temporary workaround is to maximize and restore the window. | Tested only on Intel HD integrated graphics.
 | Firefox Nightly | 95.0a1 | 11 | ✅
 | foobar2000 | 1.2.30 | 11 | ✅
 | Formula 1 | 11.0.1533 | 11 | ⚠️ | Live Timing is broken, keeps crashing on initialization


### PR DESCRIPTION
Firefox now renders correctly (on 102.1.1 (2015887775)) albeit with a weird white box when the window is small. 
![Screenshot 2022-07-06 194911](https://user-images.githubusercontent.com/31158494/177545431-5632bc1f-4023-4983-9b28-2f563825e14a.png)

A workaround is to maximize and/or restore the window for the white box to an invisible box. (Recommendation: Stay maximized at all times for the invisible box to stay small.)
![Screenshot 2022-07-06 195028](https://user-images.githubusercontent.com/31158494/177545778-a46826fd-f60a-486a-9d6e-36e0ebd289f6.png)

