### PR TITLE
Added iRobot (a.k.a. iRobot Home)

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@ wsa://com.android.settings
 | Intra | 1.3.8 | 12 | ✅ || VPN workaround is needed once after installation to allow the app to create VPN connections.
 | iOS app (any) || 11 | ❌ | Thanks for testing, Brad.
 | iPusnas | 1.5.1 | 11 | ✅
+| iRobot | 5.2.4-release | 12 | ❌ | Error message `java.lang.UnsatisfiedLinkError: dlopen failed: library "libcore_jni.so" not found`
 | JAKI - Jakarta Kini | 1.2.34 | 11 | 🆖 | Some features require GMS
 | Jet Car Stunts 2 | 1.0.13 | 11 | ❌ | Loads up but orientation and menus are broken
 | Jetpack Joyride | 1.52.1 (58461800) | 11 | ⚠️ | Google Play Games sync doesn't work, otherwise the game functionality is fine


### PR DESCRIPTION
This is the app for controlling Roomba devices (the robot vacuums).

The Java exception:

```
FATAL EXCEPTION: main
Process: com.irobot.home, PID: 2040
java.lang.UnsatisfiedLinkError: dlopen failed: library "libcore_jni.so" not found
        at java.lang.Runtime.loadLibrary0(Runtime.java:1077)
        at java.lang.Runtime.loadLibrary0(Runtime.java:998)
        at java.lang.System.loadLibrary(System.java:1656)
        at com.irobot.home.core.c.<clinit>(CoreSetup.java:1)
        at com.irobot.home.core.c.a(CoreSetup.java:1)
        at com.irobot.home.IRobotApplication.onCreate(IRobotApplication.java:4)
        at com.irobot.home.IRobotApplication_.onCreate(IRobotApplication_.java:3)
        at android.app.Instrumentation.callApplicationOnCreate(Instrumentation.java:1223)
        at android.app.ActivityThread.handleBindApplication(ActivityThread.java:6762)
        at android.app.ActivityThread.access$1500(ActivityThread.java:256)
        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2091)
        at android.os.Handler.dispatchMessage(Handler.java:106)
        at android.os.Looper.loopOnce(Looper.java:201)
        at android.os.Looper.loop(Looper.java:288)
        at android.app.ActivityThread.main(ActivityThread.java:7870)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1003)
```

Given my basic understanding of JNI, I would have thought the app would be responsible for bundling the `libcore_jni.so` dependency.

Therefore, it's strange that the app works on my physical device but doesn't work in WSA - both tested using `5.2.4-release`, since that's the latest version supported for my physical device.

I'm aware that `7.2.0` is the latest release available, but that also throws the same exception in WSA too.