### PR TITLE
Add NClientV2, fixed description for FB Messenger Lite

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ wsa://com.apple.android.music
 | Facebook | 377.0.0.22.107 | 12 | ✅ | 
 | Facebook Lite | 339.0.0.10.100 | 12 | ✅ |
 | Facebook Messenger | 330.0.0.12.116 (x86_64) | 11 | ⚠️ | Chat Heads don't work
-| Facebook Messenger Lite | 334.0.0.10.101 | ✅ | 
+| Facebook Messenger Lite | 334.0.0.10.101 | 12 | ✅ | 
 | Fancade | 1.7.6 | 11 | ❌ | App crashes
 | FAST Speed Test | 1.0.8 (88) | 11 | ✅
 | Fate/Grand Order (US) FGO | 2.34.0 | 12, 11 | 🆖 || Require Google Play Services, skippable if you have Google Play Service (APK) installed
@@ -258,6 +258,7 @@ wsa://com.apple.android.music
 | MX Player Pro | 1.39.13 | 11 | ⚠️ | App crashes, but videos can be played from external sources
 | MyPostNord (Norway) | 3.12 | 12 | ✅ 
 | My Verizon | 16.4.2 | 11 | ✅ || The page might be displayed sideways for a short amount of time when the app is launched. The app automatically reverts to correct orientation in a second.
+| NClientV2 (Release)| 3.0.2 | 13 | ✅ | Keyboard navigation is unsupported when reading. | You can try enabling `Disguise app in drawer` but it doesn't work in the Windows start menu, but works with an installed launcher like Lawnchair or Rootless Pixel Launcher.
 | Neko | 2.13.2 | 13, 12, 11 | ✅
 | Nekogram X | 8.1.2-1-rc01 | 11 | ✅ || Use NoGcm variant
 | Netflix (Aurora Store) | 8.4.0 | 11 | ❌ | "Device not supported" error


### PR DESCRIPTION
Added:
 - NClientV2 (Release) 3.0.2
Fixed (formatting):
- Facebook Messenger Lite (forgot to add the android version)