### PR TITLE
Blue Archive compatibility changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,8 +466,8 @@ wsa://com.apple.android.music
 | Command and Conquer: Rivals | 1.8.1 | 12, 11 | ✅ | | It will pop up "Won't run without GPlay services" when starts, but works fine except GPlay login. You may use link email instead.
 | Endless Frontier - Idle RPG | 3.5.3 | 12 | ❌ | OpenGL ES 3.1 is unsupported
 | Epic Seven | 1.0.406 | 11 | ⚠️ | Low FPS, unable to sign in with Google
-| Blue Archive (GB) | 1.35.231115  | 13 | ❌ | Crashed when trying to log in/enter the game.
-| Blue Archive (ブルーアーカイブ; JP) | 1.21.156614 | 12 | ✅ | Installing the HEVC video extension (9NMZLZ57R3T7) will work properly. If not installed, it will be stuck in black screen.
+| Blue Archive (GB) | 1.53.225706  | 13,12, 11 | ❌ | Crashed when trying to log in/enter the game.
+| Blue Archive (ブルーアーカイブ; JP) | 1.35.231115 | 13 | ✅ | Installing the HEVC video extension (9NMZLZ57R3T7) will work properly. If not installed, it will be stuck in black screen.
 | Blue Archive (KR) | 1.39.146794 | 12, 11| ❌ | HEVC codec support required
 | Blue Archive (KR, Onestore distributed) | 1.50.203922 | 13 | ✅ | Does not work with nvidia graphics
 | Brawl Stars | 38.159 | 11 | ❌ | Game crashes

--- a/README.md
+++ b/README.md
@@ -466,8 +466,8 @@ wsa://com.apple.android.music
 | Command and Conquer: Rivals | 1.8.1 | 12, 11 | ✅ | | It will pop up "Won't run without GPlay services" when starts, but works fine except GPlay login. You may use link email instead.
 | Endless Frontier - Idle RPG | 3.5.3 | 12 | ❌ | OpenGL ES 3.1 is unsupported
 | Epic Seven | 1.0.406 | 11 | ⚠️ | Low FPS, unable to sign in with Google
-| Blue Archive (GB) | 1.53.225706  | 13,12, 11 | ❌ | Crashed when trying to log in/enter the game.
-| Blue Archive (ブルーアーカイブ; JP) | 1.21.156614 | 12 | ❌ | Black screen on app launch
+| Blue Archive (GB) | 1.35.231115  | 13 | ❌ | Crashed when trying to log in/enter the game.
+| Blue Archive (ブルーアーカイブ; JP) | 1.21.156614 | 12 | ✅ | Installing the HEVC video extension (9NMZLZ57R3T7) will work properly. If not installed, it will be stuck in black screen.
 | Blue Archive (KR) | 1.39.146794 | 12, 11| ❌ | HEVC codec support required
 | Blue Archive (KR, Onestore distributed) | 1.50.203922 | 13 | ✅ | Does not work with nvidia graphics
 | Brawl Stars | 38.159 | 11 | ❌ | Game crashes


### PR DESCRIPTION
The Blue Archive will work properly with the HEVC video extension (9NMZLZ57R3T7) installed.