### PR TITLE
Multiple app updates (GoTyme, LANDBANK, PalawanPay, Wattpad, Shopee PH)

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ wsa://com.apple.android.music
 | Koguma | 0.0.1 | 13 | ✅
 | Kotatsu | 6.8.3 | 13 | ✅ | | Keyboard navigation is supported
 | KRL Access | 4.1.0 | 11 | ❌ | App crashes
+| LANDBANK | 6.1.1 | 13 | ✅ | The app runs for the most part, however, during the user signing up for a bank account, it alerts you to `Error: The device is incompatible with the SDK` when verifying the identity of the user signing up
 | Lawnchair | 14 beta 2 | 13, 12, 11 | ✅ | The app drawer seems to be blank in portrait. A workaround would be either maximizing the app or resize it to be in a landscape orientation. Can't change the wallpaper with a toast notification: `Disabled by your admin`.
 | Lazada | 7.37.0 | 13 | ⚠️ | Google login requires GMS installed (use Email or Facebook login as alternatives). `Slide to verify` appears too often if logging in. Weird scaling options (interface elements are too large) | Keep it in portrait for the app to be usable.
 | Libby | 4.3.1 | 11 | ✅
@@ -311,7 +312,7 @@ wsa://com.apple.android.music
 | OurGroceries | 4.0.10 | 11 | ✅ | Premium keys require Google Play Store
 | Outlook | 4.2138.0 | 11 | ⚠️ | Cannot activate device administrator with Outlook, which prevents activation.
 | Package Manager | v7.0 | 13,12 | ✅ || Recommeded with use of Shizuku for multi-app installation
-| PalawanPay | 1.0.400396 | 13 | ✅ | The app works but WSA's developer options should be disabled before opening the app as the app will lock you out if it detects it was turned on
+| PalawanPay | 1.0.4634210 | 13 | ❌ | Starting in this version, Google Play will alert you with "This app won't work for your device" and if you sideloaded an older version of the app, the app prompts you to update but when you press "Update app", it takes you to the Google Play listing, it only lets you uninstall it, or open the app.
 | Phigros || 11 | ✅
 | Philips Hue | 4.29.0 | 12 | ✅
 | Photomath | 8.22.0 | 13 | ✅ || Installed via `adb` command

--- a/README.md
+++ b/README.md
@@ -358,7 +358,7 @@ wsa://com.apple.android.music
 | Shein | 9.9.4 | 13 | ✅ || Keep it in portrait to be usable
 | ShemarooMe | 1.0.16 (106) | 11 | ✅
 | Shizuku (Play Store) | 13.5.4.r1049.0r53409 | 13, 12, 11 | ✅ | Can't toggle wireless debugging in WSA 2207.40000.8.0 (android 12), use ADB on PC to use connect instead (even with dev options and USB debugging is on). | The service also works with root (Tested with Magisk)
-| Shopee (PH) | 3.12.16 | 13, 11 | ✅ | Google login requires GMS installed (use Email or Facebook login as alternatives). Banner information is stretched horizontally 
+| Shopee (PH) | 3.12.16 | 13, 11 | ⚠️ | Any login attempt, even if Magisk DenyList is enabled for Shopee PH, would result in a ``Login Failed (F13) error: Oops, your account has been restricted due to unusual activities. Please make sure you comply with Shopee policies.`` Google login requires GMS installed (use Email or Facebook login as alternatives). Banner information is stretched horizontally 
 | Shosetsu | 2.4.4 | 13, 12 | ✅ | Keyboard navigation is unsupported when reading light novel.
 | Showtime | 3.1.1 | 11 | ❌ | App crashes when you try to login. Button clicks don't work
 | SIM Toolkit (Google) | 12, API 32 | 12 | ❌ | Does not launch even with a shortcut.

--- a/README.md
+++ b/README.md
@@ -429,6 +429,7 @@ wsa://com.apple.android.music
 | Voice Recorder | 55.1 | 12 | ✅ || com.media.bestrecorder.audiorecorder
 | VSCO | 264 | 11 | ⚠️ | Cannot sign in
 | Warden | 1.0.3.release | 11 | ⚠️ | App screen flashes otherwise functionality-wise its normal
+| Wattpad | 10.44.0 | 13 |  ✅  | *The Wattpad version tested in this WSA install (Magisk with GMS) is a modded one (no ads).* App works, including the theming and responsive design based on the window size. Online sign in works as well (tested using Facebook SSO), along with offline reading support. 
 | Wealthsimple Trade | 2.27.1 (2195) | 11 | ✅
 | WeChat | 8.0.32 | 13, 12 | ✅
 | WhatsApp | 2.21.20.20 | 11 | ⚠️ | WhatsApp cloud chat backups will not work, app was tested with microG installed

--- a/README.md
+++ b/README.md
@@ -358,7 +358,7 @@ wsa://com.apple.android.music
 | Shein | 9.9.4 | 13 | ✅ || Keep it in portrait to be usable
 | ShemarooMe | 1.0.16 (106) | 11 | ✅
 | Shizuku (Play Store) | 13.5.4.r1049.0r53409 | 13, 12, 11 | ✅ | Can't toggle wireless debugging in WSA 2207.40000.8.0 (android 12), use ADB on PC to use connect instead (even with dev options and USB debugging is on). | The service also works with root (Tested with Magisk)
-| Shopee (PH) | 3.12.16 | 13, 11 | ⚠️ | Any login attempt, even if Magisk DenyList is enabled for Shopee PH, would result in a ``Login Failed (F13) error: Oops, your account has been restricted due to unusual activities. Please make sure you comply with Shopee policies.`` Google login requires GMS installed (use Email or Facebook login as alternatives). Banner information is stretched horizontally 
+| Shopee (PH) | 3.35.31 | 13, 11 | ⚠️ | Any login attempt, even if Magisk DenyList is enabled for Shopee PH, would result in a ``Login Failed (F13) error: Oops, your account has been restricted due to unusual activities. Please make sure you comply with Shopee policies.`` Google login requires GMS installed (use Email or Facebook login as alternatives). Banner information is stretched horizontally 
 | Shosetsu | 2.4.4 | 13, 12 | ✅ | Keyboard navigation is unsupported when reading light novel.
 | Showtime | 3.1.1 | 11 | ❌ | App crashes when you try to login. Button clicks don't work
 | SIM Toolkit (Google) | 12, API 32 | 12 | ❌ | Does not launch even with a shortcut.

--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ wsa://com.apple.android.music
 | Google Play Store | 43.0.18-31 [0] [PR] 679686942 | 13 | 🆖 | Requires GMS. If you're changing languages a lot in the app, there's a prompt to restart the app to complete the update. Wait for a few seconds, then tap/click restart to proceed (sometimes works, sometimes not) or alternatively, clear the app data and open it again. | Play Protect certification status will be `Device is uncertified`
 | Google Services Framework (APK) | 12, API 32 | 12 | ❌ | Although installation succeeds and apps become aware of it, it lacks a lot of permissions needed for most functions, e.g. `read_device_config`, which can't be given even with the Settings app.
 | Google Translate | 6.45.0.474938783.2-release | 12 | ❌ | Crashes on startup due to reliance on Google Services Framework
+| GoTyme | 1.36.0 | 13 | ❌ | App crashes immediately upon launching the app 
 | Grab | 5.172.200 | 11 | ✅
 | Grayjay | 253 | 13 | ✅ || Tested with the unversal installer variant. Works well on an Intel CPU with integrated graphics (performance may vary)
 | Gycso | 1.1.0 | 12, 11 | ✅ |


### PR DESCRIPTION
### <h1>What's new in this pull request:</h1>

<h2>Added app/s:</h2>

### **GoTyme**
- Added app behavior, Android OS version compatibility

### **LANDBANK**
- Added app behavior, Android OS version compatibility

### **Wattpad**
- Added app behavior, Android OS version compatibility'


<h2>Updated app/s:</h2>

### **PalawanPay:**
  - Word changes to app behavior description
  
### **Shopee PH:**
  - Word changes to app behavior description
  
 ---
 ### Changelogs:

| Application | Latest tested version | Android versions | Support level | Known Issues | Notes |
|-------------|-----------------------|------------------|-------------------|------------------|----------|
| GoTyme | 1.36.0 | 13 | ❌ | App crashes immediately upon launching the app
| LANDBANK | 6.1.1 | 13 | ✅ | The app runs for the most part, however, during the user signing up for a bank account, it alerts you to `Error: The device is incompatible with the SDK` when verifying the identity of the user signing up
| PalawanPay | 1.0.4634210 | 13 | ❌ | Starting in this version, Google Play will alert you with "This app won't work for your device" and if you sideloaded an older version of the app, the app prompts you to update but when you press "Update app", it takes you to the Google Play listing, it only lets you uninstall it, or open the app.
| Shopee (PH) | 3.35.31 | 13, 11 | ⚠️ | Any login attempt, even if Magisk DenyList is enabled for Shopee PH, would result in a ``Login Failed (F13) error: Oops, your account has been restricted due to unusual activities. Please make sure you comply with Shopee policies.`` Google login requires GMS installed (use Email or Facebook login as alternatives). Banner information is stretched horizontally
| Wattpad | 10.44.0 | 13 | ✅ | *The Wattpad version tested in this WSA install (Magisk with GMS) is a modded one (no ads).* App works, including the theming and responsive design based on the window size. Online sign in works as well (tested using Facebook SSO), along with offline reading support.